### PR TITLE
fixed eventType get all api service

### DIFF
--- a/src/routes/api/eventType.js
+++ b/src/routes/api/eventType.js
@@ -8,7 +8,7 @@ const eventType = express.Router();
 
 eventType.get("/all", function (req, res) {
   knex
-    .select("name", "description", "defaultUrgency")
+    .select()
     .from("EventType")
     .then(data => res.status(200).json(data))
     .catch(err => res.status(500).json({ error: err.message }));


### PR DESCRIPTION
I have change knex select statement in evetType get all api service. It was showing a warning were each child should have a unique key prop, and the id where not select from database in select statement.

![eventTypes_error](https://user-images.githubusercontent.com/36608374/68524513-89687980-02d0-11ea-854e-46b6c24c8ea8.PNG)
